### PR TITLE
Add GitHub URL

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,1 +1,1 @@
-{"name": "micro-camera-privacy", "description": "Shows when microphone or camera is used", "uuid": "micro_camera_privacy@jmas.softcatala.org", "shell-version": ["3.32", "3.34"]}
+{"name": "micro-camera-privacy", "url": "https://github.com/jordimas/micro-camera-privacy", "description": "Shows when microphone or camera is used", "uuid": "micro_camera_privacy@jmas.softcatala.org", "shell-version": ["3.32", "3.34"]}


### PR DESCRIPTION
This fix will add the Extension Homepage link to [extension page](https://github.com/jordimas/micro-camera-privacy).

This link will be useful for users to send PR or check source code.